### PR TITLE
Change auth method for updating Brew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '^1.21.1'
-    - uses: tibdex/github-app-token@v2
-      id: generate_homebrew_token
-      with:
-        app_id: ${{ secrets.HOMEBREW_APP_ID }}
-        private_key: ${{ secrets.HOMEBREW_APP_PRIVKEY }}
+    # - uses: tibdex/github-app-token@v2
+    #   id: generate_homebrew_token
+    #   with:
+    #     app_id: ${{ secrets.HOMEBREW_APP_ID }}
+    #     private_key: ${{ secrets.HOMEBREW_APP_PRIVKEY }}
     - name: Release via goreleaser
       uses: goreleaser/goreleaser-action@v5
       with:
@@ -28,5 +28,5 @@ jobs:
         args: release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HOMEBREW: ${{ steps.generate_homebrew_token.outputs.token }}
+        # HOMEBREW: ${{ steps.generate_homebrew_token.outputs.token }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,8 @@ brews:
       branch: main
 
       # # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-      token: "{{ .Env.HOMEBREW }}"
+      # token: "{{ .Env.HOMEBREW }}" 
+      token: "{{ .Env.GITHUB_TOKEN}}"      
 
     # Template for the url which is determined by the given Token (github or gitlab)
     # Default for github is "https://github.com/<repo_owner>/<repo_name>/releases/download/{{ .Tag }}/{{ .ArtifactName }}"


### PR DESCRIPTION
While the original implementation relied on a GitHub App to access and update the HomeBrew-tap, it seems that with jenkins-infra, the GITHUB-TOKEN has some extra powers.