### PR TITLE
fix: use "goreleaser in jenkins-infra" GitHub App credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     - uses: tibdex/github-app-token@v2
       id: generate_homebrew_token
       with:
-        app_id: ${{ secrets.HOMEBREW_APP_ID }}
-        private_key: ${{ secrets.HOMEBREW_APP_PRIVKEY }}
+        app_id: ${{ secrets.GORELEASER_APP_ID }}
+        private_key: ${{ secrets.GORELEASER_APP_PRIVKEY }}
     - name: Release via goreleaser
       uses: goreleaser/goreleaser-action@v5
       with:


### PR DESCRIPTION
This PR fixes the goreleaser GitHub Action process by setting the credentials it uses to the new "goreleaser in jenkins-infra" GitHub App.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4141#issuecomment-2178299100