### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Order is important. The last matching pattern has the most precedence.
+* @jenkins-infra/contribution-stats


### PR DESCRIPTION
This PR adds a CODEOWNERS file to automatically add @jenkins-infra/contribution-stats team as reviewer on pull requests.